### PR TITLE
added warning about the use of the reader role

### DIFF
--- a/docs/_openstack/quickstart/manager_role/index.de.md
+++ b/docs/_openstack/quickstart/manager_role/index.de.md
@@ -105,6 +105,8 @@ group remove user $GROUP $USER
 
 ### Rollenzuweisungen
 
+**Wichtig:** Vergeben sie ausschließlich die Rolle "member" - die Rolle "reader" steht im System zur Verfügung, die effektiven Berechtigungen sind jedoch nicht read-only. 
+
 ```bash
 # Rolle einem Benutzer in einem Projekt zuweisen
 role add --user $USER --project $PROJECT member

--- a/docs/_openstack/quickstart/manager_role/index.en.md
+++ b/docs/_openstack/quickstart/manager_role/index.en.md
@@ -100,6 +100,9 @@ group remove user $GROUP $USER
 ```
 
 ### Role Assignmments
+
+**Important:** Only assign the "member" Role - the "reader" role is available in the system but the effective permissions are not read-only when using the "reader" role.
+
 ```bash
 # Assign role to a user in a project
 role add --user $USER --project $PROJECT member


### PR DESCRIPTION
The reader role should not be used because it does not grant read-only permissions.