### PR TITLE
changed from domain name to domain id for manager commands

### DIFF
--- a/docs/_openstack/quickstart/manager_role/index.de.md
+++ b/docs/_openstack/quickstart/manager_role/index.de.md
@@ -38,13 +38,20 @@ openstack --os-username $MANAGER_USERNAME \
 $COMMAND
 ```
 
-Als Domain-Manager können Sie Benutzer, Projekte, Gruppen und Rollen mit folgenden Befehlen verwalten:
+Als Domain-Manager können Sie Benutzer, Projekte, Gruppen und Rollen mit den folgenden Befehlen verwalten, nutzen Sie dazu die Befehle in Kombination mit den obenstehenden Parametern:
+
+### Abfragen der Domain ID 
+```bash
+# Abfragen der Domain ID
+domain show $DOMAIN_NAME
+```
+**Wichtig:** Die Domain ID wird für die folgenden Befehle benötigt.
 
 ### Benutzerverwaltung
 
 ```bash
 # Benutzer erstellen
-user create --domain $DOMAIN_NAME --password-prompt $USER
+user create --domain $DOMAIN_ID --password-prompt $USER
 
 # Alle Benutzer in der Domain auflisten
 user list
@@ -73,7 +80,7 @@ openstack credential create --type totp --secret $BASE_32_2FA_SECRET $USER_ID
 
 ```bash
 # Neues Projekt erstellen
-project create $PROJECT --domain $DOMAIN_NAME
+project create $PROJECT --domain $DOMAIN_ID
 
 # Alle Projekte auflisten
 project list
@@ -88,7 +95,7 @@ project delete $PROJECT
 
 ```bash
 # Gruppe erstellen
-group create $GROUP --domain $DOMAIN_NAME
+group create $GROUP --domain $DOMAIN_ID
 
 # Gruppen auflisten
 group list

--- a/docs/_openstack/quickstart/manager_role/index.en.md
+++ b/docs/_openstack/quickstart/manager_role/index.en.md
@@ -37,13 +37,20 @@ openstack --os-username $MANAGER_USERNAME \
 $COMMAND
 ```
 
-As a domain manager you are able to manage users, projects, groups and role assignments with the following commands: 
+As a domain manager you are able to manage users, projects, groups and role assignments with the following commands combined with the CLI objections above: 
+
+### Obtaining the Domain ID
+```bash
+# Obtain the Domain ID
+domain show $DOMAIN_NAME
+```
+**Important:** The Domain ID is needed for the commands below.
 
 ### User Management
 
 ```bash
 # Create a user
-user create --domain $DOMAIN_NAME --password-prompt $USER
+user create --domain $DOMAIN_ID --password-prompt $USER
 
 # List all users in your domain
 user list
@@ -71,7 +78,7 @@ openstack credential create --type totp --secret $BASE_32_2FA_SECRET $USER_ID
 ### Project Management
 ```bash
 # Create a new project
-project create $PROJECT --domain $DOMAIN_NAME
+project create $PROJECT --domain $DOMAIN_ID
 
 # List all projects
 project list
@@ -84,7 +91,7 @@ project delete $PROJECT
 ### Group Management
 ```bash
 # Create a group
-group create $GROUP --domain $DOMAIN_NAME
+group create $GROUP --domain $DOMAIN_ID
 
 # List groups
 group list


### PR DESCRIPTION
Because the OpenStack Client treats numerical Domain Names as Domain IDs resulting in 403s we changed the commands to use the domain ID instead.
Also added a block to obtain the Domain ID from the Domain Name as a manager user.