### PR TITLE
fix: correct typos, grammar, and heading style across docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,7 +63,7 @@ plugins:
 
 # Styles
 # WORKAROUND
-# We disable sourcemaps, otherwhise i18n via polyglot leads to broken styles compiled from scss
+# We disable sourcemaps, otherwise i18n via polyglot leads to broken styles compiled from scss
 # See <https://github.com/untra/polyglot#compatibility>, <https://github.com/untra/polyglot/issues/107#issuecomment-598274075>
 sass:
   sourcemap: never

--- a/docs/_openstack/faq/index.en.md
+++ b/docs/_openstack/faq/index.en.md
@@ -159,7 +159,7 @@ Attempts to use multi-attached volumes without cluster-capable file systems carr
 ## Why am I unable to create a snapshot of a running instance?
 
 In order to provide consistent snapshots, the OpenStack Platform utilises the property [os_require_quiesce=yes](https://opendev.org/openstack/nova/commit/926e58a179ef373646164bea40dc46b1ebef4748).
-This property allows `fsfreeze` to suspend and resume access on running instances and ensures ensures that a consistent image is created from the disk.
+This property allows `fsfreeze` to suspend and resume access on running instances and ensures that a consistent image is created from the disk.
 
 The OpenStack Platform supports the following options to facilitate the creation of snapshots on running instances:
 

--- a/docs/_openstack/specs/default_quota/index.de.md
+++ b/docs/_openstack/specs/default_quota/index.de.md
@@ -7,13 +7,11 @@ nav_order: 9200
 last_modified_date: 2025-07-21
 ---
 
-OpenStack Default Quotas
-========================
+# OpenStack Default Quotas
 
-Im der Openstack Plattform haben wir Standardwerte für den OpenStack Compute-Dienst, den OpenStack Block Storage-Dienst und den OpenStack Networking-Dienst definiert. Wir haben auch separate Quotas für den Octavia Loadbalancer-Dienst und die zugehörigen Komponenten. Diese Standardwerte für neu erstellte Projekte sind unten aufgeführt, sollten sie eine Anpassung benötigen erstellen sie bitte ein Ticket über unseren Helpdesk: [helpdesk.de@wiit.one](mailto:helpdesk.de@wiit.one)
+In der OpenStack-Plattform haben wir Standardwerte für den OpenStack Compute-Dienst, den OpenStack Block Storage-Dienst und den OpenStack Networking-Dienst definiert. Wir haben auch separate Quotas für den Octavia Loadbalancer-Dienst und die zugehörigen Komponenten. Diese Standardwerte für neu erstellte Projekte sind unten aufgeführt, sollten sie eine Anpassung benötigen erstellen sie bitte ein Ticket über unseren Helpdesk: [helpdesk.de@wiit.one](mailto:helpdesk.de@wiit.one)
 
-Compute
-----------------
+## Compute
 
 |**Field**                 |**Value**            |
 |:-------------------------|:--------------------|
@@ -28,8 +26,7 @@ Compute
 | Server Groups            |        10           |
 | Server Group Members     |        10           |
 
-Block Storage
-----------------------
+## Block Storage
 
 |**Field**                 |**Value**            |
 |:-------------------------|:--------------------|
@@ -40,8 +37,7 @@ Block Storage
 | Snapshots                |        100          |
 | Volumes                  |        100          |
 
-Network
-----------------
+## Network
 
 |**Field**                 |**Value**            |
 |:-------------------------|:--------------------|
@@ -55,8 +51,7 @@ Network
 | RBAC Policies            |        100          |
 | Subnetpools              |        Unlimited    |
 
-Octavia Loadbalancers
-----------------
+## Octavia Loadbalancers
 
 |**Field**                 |**Value**            |
 |:-------------------------|:--------------------|

--- a/docs/_openstack/specs/default_quota/index.en.md
+++ b/docs/_openstack/specs/default_quota/index.en.md
@@ -7,13 +7,11 @@ nav_order: 9200
 last_modified_date: 2025-07-21
 ---
 
-OpenStack Default Quotas
-========================
+# OpenStack Default Quotas
 
 In the OpenStack-Platform we have defined default quotas for the OpenStack Compute service, the OpenStack Block Storage service, and the OpenStack Networking service. We also have separate quotas for the Octavia Loadbalancer service and its associated components. These default values for new projects are listed below, if you need some quota to be increased please open a ticket for it via [helpdesk.de@wiit.one](mailto:helpdesk.de@wiit.one)
 
-Compute
-----------------
+## Compute
 
 |**Field**                 |**Value**            |
 |:-------------------------|:--------------------|
@@ -28,8 +26,7 @@ Compute
 | Server Groups            |        10           |
 | Server Group Members     |        10           |
 
-Block Storage
-----------------------
+## Block Storage
 
 |**Field**                 |**Value**            |
 |:-------------------------|:--------------------|
@@ -40,8 +37,7 @@ Block Storage
 | Snapshots                |        100          |
 | Volumes                  |        100          |
 
-Network
-----------------
+## Network
 
 |**Field**                 |**Value**            |
 |:-------------------------|:--------------------|
@@ -55,8 +51,7 @@ Network
 | RBAC Policies            |        100          |
 | Subnetpools              |        Unlimited    |
 
-Octavia Loadbalancers
-----------------
+## Octavia Loadbalancers
 
 |**Field**                 |**Value**            |
 |:-------------------------|:--------------------|

--- a/docs/_openstack/specs/flavor_specification/index.de.md
+++ b/docs/_openstack/specs/flavor_specification/index.de.md
@@ -9,7 +9,7 @@ last_modified_date: 2025-07-21
 
 # Flavor Spezifikationen
 
-"Flavor" bezeichnet im OpenStack-Kontext ein Hardware-Profil, das eine virtuelle Maschine nutzt bzw. nutzen kann. Im der OpenStack-Plattform
+"Flavor" bezeichnet im OpenStack-Kontext ein Hardware-Profil, das eine virtuelle Maschine nutzt bzw. nutzen kann. In der OpenStack-Plattform
 sind diverse Standard-Hardwareprofile (Flavors) eingerichtet. Diese haben unterschiedliche Limits und Begrenzungen, welche hier für alle
 verfügbaren Flavors aufgelistet sind.
 

--- a/docs/_openstack/specs/flavor_specification/index.en.md
+++ b/docs/_openstack/specs/flavor_specification/index.en.md
@@ -26,7 +26,7 @@ To change the flavors of existing instances, the OpenStack ["Resize Instance"](/
 
 All default flavors are available in all availability zones as well as in SZ1 by default, unless specified otherwise.
 In addition to the standard variant with a 20GB root disk, we offer a .d variant with a 100GB root disk.
-Alternatively, any flavor can used with a volume as the root disk.
+Alternatively, any flavor can be used with a volume as the root disk.
 
 ### s1 (Standard) Flavors
 

--- a/docs/_openstack/specs/images/index.en.md
+++ b/docs/_openstack/specs/images/index.en.md
@@ -36,7 +36,7 @@ The current list of images is as follows:
 - Rocky Linux 9
 - Flatcar Linux
 
-These images are checked for new releases daily. The latest available version is always a public image, and contains the `Latest`-suffix. All previous versions of an imags are automatically converted to "community images", renamed (`Latest` is replaced by the date of the first upload), and eventially deleted if they are no longer in use at all.
+These images are checked for new releases daily. The latest available version is always a public image, and contains the `Latest`-suffix. All previous versions of an image are automatically converted to "community images", renamed (`Latest` is replaced by the date of the first upload), and eventually deleted if they are no longer in use at all.
 
 OpenStack and many deployment tools support using these images either by name or by their UUID. By using a name, for example `Ubuntu 24.04 Noble Numbat - Latest`, you can easily stay up to date by redeploying or rebuilding your instances, even if we replace the image in the interim. You can avoid this behaviour by using the UUID instead. This may be useful for cluster deployments, where you want to ensure that all nodes are running the same version of the image.
 


### PR DESCRIPTION
- images/index.en.md: fix 'imags' → 'image', 'eventially' → 'eventually'
- flavor_specification/index.en.md: fix missing 'be' in 'can be used'
- faq/index.en.md: remove duplicate word 'ensures ensures'
- flavor_specification/index.de.md: fix 'Im der' → 'In der'
- default_quota/index.de.md: fix 'Im der Openstack' → 'In der OpenStack-Plattform'
- default_quota/index.{en,de}.md: convert Setext headings to ATX style
- _config.yml: fix 'otherwhise' → 'otherwise'